### PR TITLE
Write file to a temporary file to avoid file corruption when FS is full

### DIFF
--- a/src/main/scala/geonosis/ZookeeperSync.scala
+++ b/src/main/scala/geonosis/ZookeeperSync.scala
@@ -1,5 +1,7 @@
 package geonosis
 
+import java.io.File
+
 import scala.collection.JavaConverters._
 import scala.util.Try
 
@@ -43,8 +45,10 @@ class ZookeeperSync(val zookeeperServers: String, val zkNodes: Seq[String], val 
 
   def dump(actions: Map[Path, Array[Byte]]): Unit = {
     actions.foreach { case (path, data) =>
-      debug(s"Writing $path")
-      path.write(data)
+      val tempPath: Path = File.createTempFile("geonosis", "tmp")
+      debug(s"Writing $path to $tempPath")
+      tempPath.write(data)
+      tempPath.moveTo(path, true, true)
     }
   }
 


### PR DESCRIPTION
When overwriting an existing file, it is truncated and it could then fail if the
filesystem is full. A valid file as thus been replaced by an empty one.
Using a temporary file for writing should prevent this behavior as writing to
the temporary file might fails before replacing the valid one.